### PR TITLE
Support SCSS

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -1,0 +1,6 @@
+html {overflow-y: scroll}
+body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
+code{color: #FFFFFF; background:#000000; padding:2px}
+pre{color: #FFFFFF; background:#000000; padding:24px; white-space: pre-wrap}
+article{padding:20px 0}
+.center {display: block;margin-left: auto;margin-right: auto;width: 100%;}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,0 +1,1 @@
+@import "base.scss";

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,1 +1,3 @@
+@charset "utf-8";
+
 @import "base.scss";

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,8 @@
 	<title>{{ .Title }}</title>
 	{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
-	<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+	{{ $style := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
+	<link rel="stylesheet" href="{{ $style.Permalink }}">
 	{{ with .OutputFormats.Get "RSS" -}}
 		{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{- end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,0 @@
-html {overflow-y: scroll}
-body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
-code{color: #FFFFFF; background:#000000; padding:2px}
-pre{color: #FFFFFF; background:#000000; padding:24px; white-space: pre-wrap}
-article{padding:20px 0}
-.center {display: block;margin-left: auto;margin-right: auto;width: 100%;}


### PR DESCRIPTION
Added support for SCSS.

## Why
Using the SCSS will enable you to:

- isolate the base CSS
- use variables
- combine your added CSS into a single file
- compress and add fingerprinting (Hugo's features)

## Usage
Copy `assets/scss` under the theme directory to your Hugo's `assets/scss` directory.

```bash
$ cp -R ./themes/smol/assets/scss ./assets/scss
```

You have added the SCSS file, import it from base.scss.

```diff
  @charset "utf-8";

  @import "base.scss";
+ @import "./custom.scss";
```