### PR TITLE
Change Ruboto mono font

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -1,5 +1,5 @@
 html {overflow-y: scroll}
-body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
+body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 'Roboto Mono', monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
 code{color: #FFFFFF; background:#000000; padding:2px}
 pre{color: #FFFFFF; background:#000000; padding:24px; white-space: pre-wrap}
 article{padding:20px 0}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,6 +10,7 @@
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 	{{ $style := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
 	<link rel="stylesheet" href="{{ $style.Permalink }}">
+	<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap" rel="stylesheet">
 	{{ with .OutputFormats.Get "RSS" -}}
 		{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{- end }}


### PR DESCRIPTION
In Japan, when you choose `font-family: monospace;` it will be automatically set as the Osaka font which is not monospaced.
Therefore I chose `font-family: Ruboto mono`, which is similar in Google fonts.

**Before**
<img width="200" alt="スクリーンショット 2020-07-12 20 02 20" src="https://user-images.githubusercontent.com/6420854/87244790-e5485b00-c47a-11ea-83e5-bae0cfbb70da.png">

↓

**After**
<img width="200" alt="スクリーンショット 2020-07-12 20 02 50" src="https://user-images.githubusercontent.com/6420854/87244792-e6798800-c47a-11ea-9c21-49fa95441e91.png">


