### PR TITLE
Added modifiable title separator

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header>
-	{{ strings.Repeat ( .Site.Title | len | add 6 ) "=" }}<br>
-	== <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a> ==<br>
-	{{ strings.Repeat ( .Site.Title | len | add 6 ) "=" }}
+	{{ .Site.Params.titleSeparator | default "=" | strings.Repeat ( .Site.Title | len | add 6 ) }}<br>
+	{{ .Site.Params.titleSeparator | default "=" | strings.Repeat 2 }} <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a> {{ .Site.Params.titleSeparator | default "=" | strings.Repeat 2 }}<br>
+	{{ .Site.Params.titleSeparator | default "=" | strings.Repeat ( .Site.Title | len | add 6 ) }}<br>
 	<div style="float: right;">{{ .Site.Params.subtitle }}</div><br>
 	<p>
 	<nav>


### PR DESCRIPTION
You can modify the title separator.

## Usage
Add `titleSeparator` parameter on config.toml.

```toml
[params]
  titleSeparator = "*"
```

It will look like this.

<img width="200" alt="スクリーンショット 2020-07-12 23 44 09" src="https://user-images.githubusercontent.com/6420854/87249362-9b22a200-c499-11ea-8a75-e6b0fc574041.png">
