### PR TITLE
Remove start link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,6 @@
 	<div style="float: right;">{{ .Site.Params.subtitle }}</div><br>
 	<p>
 	<nav>
-			<a href="/"><b>Start</b></a>.
 			{{ with .Site.Menus.main }}
 			{{ range . }}
 			<a href="{{ .URL | relURL }}"><b>{{ .Name }}</b></a>.


### PR DESCRIPTION
I don't need `start` link.

<img width="250" alt="スクリーンショット 2020-07-12 23 48 00" src="https://user-images.githubusercontent.com/6420854/87249463-3582e580-c49a-11ea-961e-0976fbcea290.png">
