### PR TITLE
Change date format

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
 		    <li>
 		        <div class="post-title">
 				{{ if eq $listtitle "Posts" }}
-				    {{ .Date.Format "2006-01-02" }} <a href="{{ .RelPermalink }}">{{.Title }}</a>
+					{{ .Date.Format "January 02, 2006" }} <a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ else }}
 				    <a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
 	<main>
 		<article>
 			<h1>{{ .Title }}</h1>
-			<b><time>{{ .Date.Format "02.01.2006 15:04" }}</time></b>
+			<b><time>{{ .Date.Format "January 02, 2006" }}</time></b>
 		       {{ range .Params.tags }}
 		           <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
         	       {{ end }}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,6 +1,6 @@
 <article>
 	<h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
-	<b><time>{{ .Date.Format "02.01.2006 15:04" }}</time></b>
+	<b><time>{{ .Date.Format "January 02, 2006" }}</time></b>
 	{{ range .Params.tags }}
 	<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
 	{{ end }}


### PR DESCRIPTION
The common date format in Japan is YYYY-MM-DD.
For this reason, it is difficult to distinguish the month and day in the worldwide date format, so we have changed the format to "January 02, 2006" which is easy to understand.